### PR TITLE
only return a 404 status code in a case someone hits a non-existent API route

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -86,8 +86,8 @@ async fn not_found_handler() -> impl IntoResponse {
     not_found()
 }
 
-fn not_found() -> (StatusCode, Json<EmptyJson>) {
-    (StatusCode::NOT_FOUND, Json(EmptyJson {}))
+fn not_found() -> StatusCode {
+    StatusCode::NOT_FOUND
 }
 
 type PoolExt = Arc<Pool<Sqlite>>;


### PR DESCRIPTION
Used to return an empty JSON in addition to the 404, changed to just be an empty 404.