### PR TITLE
move the audio count to a server-side API call

### DIFF
--- a/site/src/lib/store.ts
+++ b/site/src/lib/store.ts
@@ -1,4 +1,4 @@
-import { get, writable } from 'svelte/store';
+import { get, readable, writable } from 'svelte/store';
 import { dev } from '$app/environment';
 
 export const API_URL: string = dev ? 'http://localhost:8080' : 'https://api.howsthevolu.me';


### PR DESCRIPTION
This moves the audio count from a static value that I had to manually set each time I updated the number of files, to an API call. This means I just need to upload the files and mayyyybe invalidate the cache, as opposed to having to update the front end and whatnot.

There's a local fallback to 43 included as well.